### PR TITLE
Bug 915115 - Set an explicit responseType so JS is not interpreted as HTML/XML

### DIFF
--- a/xpcom/fake-server-support.js
+++ b/xpcom/fake-server-support.js
@@ -106,6 +106,7 @@ function synchronousReadFile(path) {
   var XHR = Components.Constructor('@mozilla.org/xmlextras/xmlhttprequest;1');
   var req = new XHR();
   req.open('GET', path, false);
+  req.responseType = 'text';
   req.send();
   return req.responseText;
 }


### PR DESCRIPTION
r? @lightsofapollo
