### PR TITLE
Bug 972514 - [B2G][Email]Flagged Hotmail emails do not display the changed on or off flag indicator when synced from the server to the device using ActiveSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-fakeservers",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "fake imap/pop3/smtp servers from comm-central",
   "main": "index.js",
   "scripts": {

--- a/xpcom/subscript/activesync_server.js
+++ b/xpcom/subscript/activesync_server.js
@@ -611,6 +611,7 @@ ActiveSyncServer.prototype = {
     const as = ActiveSyncCodepages.AirSync.Tags;
     const asb = ActiveSyncCodepages.AirSyncBase.Tags;
     const asEnum = ActiveSyncCodepages.AirSync.Enums;
+    const em = ActiveSyncCodepages.Email.Tags;
 
     let syncKey, collectionId, getChanges,
         server = this,
@@ -1274,6 +1275,16 @@ ActiveSyncServer.prototype = {
         subject: msg.subject
       };
     });
+  },
+
+  _backdoor_modifyMessagesInFolder: function(data) {
+    let folder = this._findFolderById(data.folderId);
+
+    data.serverIds.forEach(function(id) {
+      let message = folder.findMessageById(id);
+      folder.changeMessage(message, data.changes);
+    });
+    return true;
   },
 
   _backdoor_changeCredentials: function(data) {


### PR DESCRIPTION
Support modifying messages without explicit client interaction
