### PR TITLE
strict mode and default prototype uses Object toString which is not writeable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-fakeservers",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "fake imap/pop3/smtp servers from comm-central",
   "main": "index.js",
   "scripts": {

--- a/xpcom/modules/mimeParserHeaders.js
+++ b/xpcom/modules/mimeParserHeaders.js
@@ -69,7 +69,9 @@ function getHeaderTokens(value, delimiters, opts) {
       token = token.replace(/\\(.?)/g, "$1");
     this.token = token;
   }
-  Token.prototype.toString = function () { return this.token; };
+  Token.prototype = {
+    toString: function () { return this.token; }
+  };
 
   let tokenStart = undefined;
   let wsp = " \t\r\n";


### PR DESCRIPTION
Workaround for [bug 980752](https://bugzilla.mozilla.org/show_bug.cgi?id=980752), so that the toString setup works.
