### PR TITLE
[Bug 825538] [email/activesync] Need to allocate unique device ID's for multi-device access to ActiveSync.

### DIFF
--- a/lib/control_request.js
+++ b/lib/control_request.js
@@ -9,6 +9,11 @@ var http = require('http'),
  * @param {Function} callback [Error err, Object json].
  */
 function request(target, details, callback) {
+  if (!callback) {
+    throw new Error('Callback needed for target: ' + target + ': ' +
+                    JSON.stringify(details));
+  }
+
   var body = JSON.stringify(details);
   var options = url.parse(target);
   options.headers = {

--- a/lib/control_server.js
+++ b/lib/control_server.js
@@ -26,6 +26,9 @@ ControlServer.prototype = {
    * @param {Function} callback [Error err, Object json].
    */
   request: function(details, callback) {
+    if (!callback) {
+      throw new Error('You need to provide a callback!');
+    }
     var url = 'http://localhost:' + this.controlPort + '/' + this.controlPath;
     controlRequest(url, details, callback);
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-fakeservers",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "fake imap/pop3/smtp servers from comm-central",
   "main": "index.js",
   "scripts": {

--- a/xpcom/subscript/activesync_server.js
+++ b/xpcom/subscript/activesync_server.js
@@ -351,6 +351,10 @@ function ActiveSyncServer(options) {
   this._nextFolderSyncId = 1;
   this._folderSyncStates = {};
 
+  // Track all the device id's we have seen so that we can return them when
+  // requested by the control server
+  this._observedDeviceIds = [];
+
   this.addFolder('Inbox', folderType.DefaultInbox);
   this.addFolder('Sent Mail', folderType.DefaultSent);
   this.addFolder('Trash', folderType.DefaultDeleted);
@@ -475,6 +479,12 @@ ActiveSyncServer.prototype = {
             query[decodeURIComponent(param.substring(0, idx))] =
               decodeURIComponent(param.substring(idx + 1));
           }
+        }
+
+        // Log the device id we saw
+        let deviceId = query.DeviceId;
+        if (this._observedDeviceIds.indexOf(deviceId) === -1) {
+          this._observedDeviceIds.push(deviceId);
         }
 
         // XXX: Only try to decode WBXML when the client actually sent WBXML
@@ -1300,4 +1310,12 @@ ActiveSyncServer.prototype = {
       folder.removeMessageById(serverId);
     });
   },
+
+  _backdoor_getObservedDeviceIds: function(data) {
+    var ids = this._observedDeviceIds;
+    if (data.clearObservedDeviceIds) {
+      this._observedDeviceIds = [];
+    }
+    return ids;
+  }
 };


### PR DESCRIPTION
Track observed device ids and be able to report them.

Some apparent sanity-checking logic I added in the past but never got around to
releasing.
