### PR TITLE
activesync fake-server creator can specify debug mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-fakeservers",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "fake imap/pop3/smtp servers from comm-central",
   "main": "index.js",
   "scripts": {

--- a/xpcom/fake-server-support.js
+++ b/xpcom/fake-server-support.js
@@ -374,7 +374,8 @@ function makeActiveSyncServer(creds, deliveryMode, logToDump) {
     };
 
     server.logResponseError = function(err) {
-      dump("ERR " + err + '\n\n');
+      dump("\x1b[31m!!! ERR " + err + '\n\n');
+      dump('\x1b[0m\n');
     };
   }
 
@@ -527,7 +528,7 @@ console.log('----> responseData:::', responseData);
     else if (reqObj.command === 'make_activesync') {
       var serverInfo = makeActiveSyncServer(reqObj.credentials,
                                             reqObj.deliveryMode,
-                                            /* debug: log traffic */ false);
+                                            reqObj.debug || false);
       this.activeSyncServersByPort[serverInfo.port] = serverInfo;
       return {
         // the control URL is also the ActiveSync server

--- a/xpcom/subscript/activesync_server.js
+++ b/xpcom/subscript/activesync_server.js
@@ -643,7 +643,9 @@ ActiveSyncServer.prototype = {
         if (wbxmlResponse) {
           response.setStatusLine('1.1', wbxmlResponse.statusCode || 200, 'OK');
           response.setHeader('Content-Type', 'application/vnd.ms-sync.wbxml');
-          response.write(encodeWBXML(wbxmlResponse));
+          if ('bytes' in wbxmlResponse) {
+            response.write(encodeWBXML(wbxmlResponse));
+          }
           if (this.logResponse)
             this.logResponse(request, response, wbxmlResponse);
         }
@@ -1376,7 +1378,7 @@ ActiveSyncServer.prototype = {
       inboxFolder.addMessage(message);
     }
 
-    return null;
+    return { statusCode: 200 };
   },
 
   _backdoorHandler: function(request, response) {


### PR DESCRIPTION
Figuring out what's up with ActiveSync fake-server issues or just ActiveSync
in general can be confusing.  The problem in this case turned out to be a
Gecko regression (and necessitated use of wireshark to further diagnose), but
this is still useful.
