### PR TITLE
Make smtpd report a 451 error if newlines are wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-fakeservers",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "fake imap/pop3/smtp servers from comm-central",
   "main": "index.js",
   "scripts": {

--- a/xpcom/subscript/maild.js
+++ b/xpcom/subscript/maild.js
@@ -365,6 +365,16 @@ nsMailReader.prototype = {
     var line = String.fromCharCode.apply(null, buf.slice(0, crlfLoc));
     this._buffer = buf.slice(crlfLoc + 2);
     this._lines.push(line);
+    // Look if there were any \n's in there that weren't preceded by an \r.
+    // (Which will be any \n we find!)
+    var idxUnpaired = line.indexOf('\n');
+    if (idxUnpaired !== -1) {
+      // Okay, the handler needs to care, for example smtpd wants to get super
+      // upset at this (and does).
+      if (this._handler._handleUnpairedLF) {
+        this._handler._handleUnpairedLF(line);
+      }
+    }
     this._findLines();
   },
 


### PR DESCRIPTION
Thanks to qmail on yahoo.co.jp for pointing this out to us!
