### PR TITLE
Bug 1096058 support to allow initial folders to be specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-fakeservers",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "fake imap/pop3/smtp servers from comm-central",
   "main": "index.js",
   "scripts": {

--- a/xpcom/fake-server-support.js
+++ b/xpcom/fake-server-support.js
@@ -215,7 +215,7 @@ function makeIMAPServer(creds, opts) {
 
   var imapExtensions = (opts && opts.imapExtensions) || ['RFC2195'];
 
-  var daemon = new imapSandbox.imapDaemon(0);
+  var daemon = new imapSandbox.imapDaemon(opts || {}, null);
   daemon.kUsername = creds.username;
   daemon.kPassword = creds.password;
   daemon.kSmtpPassword = creds.outgoingPassword;


### PR DESCRIPTION
This allows bug 1096058 to have the server start life without a Sent or
Trash folder.

This also:
- Makes us return the RFC 5530 ALREADYEXISTS reponse code if the folder
  already exists.  Arguably this is something that should be mixed in,
  but there isn't really any advantage to not reporting this in some
  cases.  And we want to abandon this in favor of hoodiecrow, so it'd
  be somewhat wasted effort.
- Allow the timezone to be specified as well.  This is in support of
  some other fake-server enhancements to use specific timezones
  instead of the system timezone.
