### PR TITLE
Make the hoodiecrow fakeserver understand folderConfig too.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-fakeservers",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "fake imap/pop3/smtp servers from comm-central",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The imapd fake-server grew the "folderConfig" support in parallel to the
use-hoodiecrow patch.  When landing hoodiecrow and given the other things
going on at the time, we decided we would not implement support until we
changed something that needed it, etc.

This has now happened in bug 1169589.